### PR TITLE
Update to `tree-sitter-language-pack`; Enforce code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: "6.0.1"
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+
+  - repo: https://github.com/psf/black
+    rev: "25.1.0"
+    hooks:
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     "pytest>=8.4.0",
     "streamlit>=1.46.0",
     "streamlit-agraph>=0.0.45",
-    "tree-sitter<0.21.0",
-    "tree-sitter-languages>=1.10.2",
+    "tree-sitter>=0.22.0",
+    "tree-sitter-language-pack>=0.9.0",
     "typer>=0.16.0",
     "uvicorn>=0.24.0",
 ]
@@ -34,5 +34,16 @@ build-backend = "hatchling.build"
 pythonpath = ["src"]
 testpaths = ["test"]
 
+[[tool.uv.index]]
+url = "https://pypi.org/simple"
+default = true
+
 [dependency-groups]
-dev = ["pyright>=1.1.402", "ruff>=0.12.1", "black", "isort", "pre-commit"]
+dev = [
+    "pyright>=1.1.402",
+    "ruff>=0.12.1",
+    "black",
+    "isort",
+    "pre-commit",
+    "pytest-xdist",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,7 @@ name = "tree-climber"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-authors = [
-    { name = "bstee615", email = "benjaminjsteenhoek@gmail.com" }
-]
+authors = [{ name = "bstee615", email = "benjaminjsteenhoek@gmail.com" }]
 requires-python = ">=3.12.4,<3.13"
 dependencies = [
     "debugpy>=1.8.14",
@@ -33,15 +31,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
-pythonpath = [
-  "src"
-]
-testpaths = [
-    "test",
-]
+pythonpath = ["src"]
+testpaths = ["test"]
 
 [dependency-groups]
-dev = [
-    "pyright>=1.1.402",
-    "ruff>=0.12.1",
-]
+dev = ["pyright>=1.1.402", "ruff>=0.12.1", "black", "isort", "pre-commit"]

--- a/src/tree_climber/ast_utils.py
+++ b/src/tree_climber/ast_utils.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Callable, List, Optional
 
 from tree_sitter import Node, Tree
-from tree_sitter_languages import get_parser
+from tree_sitter_language_pack import get_parser
 
 
 def parse_source_to_ast(source_code: str, language: str) -> Tree:

--- a/src/tree_climber/cfg/builder.py
+++ b/src/tree_climber/cfg/builder.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from tree_sitter import Tree
-from tree_sitter_languages import get_parser
+from tree_sitter_language_pack import get_parser
 
 from tree_climber.cfg.visitor import CFG, CFGVisitor
 

--- a/src/tree_climber/cfg/languages/c.py
+++ b/src/tree_climber/cfg/languages/c.py
@@ -58,9 +58,9 @@ class CCFGVisitor(CFGVisitor):
                 identifier = None
                 for child in node.children:
                     if child.type == "identifier":
-                        assert identifier is None, (
-                            "Multiple identifiers found in call expression"
-                        )
+                        assert (
+                            identifier is None
+                        ), "Multiple identifiers found in call expression"
                         identifier = get_source_text(child)
                 return identifier
             return None
@@ -162,12 +162,12 @@ class CCFGVisitor(CFGVisitor):
                     first_entry = result.entry_node_id
                 last_exits = result.exit_node_ids
 
-        assert first_entry is not None, (
-            "Translation unit must have at least one entry node"
-        )
-        assert last_exits is not None, (
-            "Translation unit must have at least one exit node"
-        )
+        assert (
+            first_entry is not None
+        ), "Translation unit must have at least one entry node"
+        assert (
+            last_exits is not None
+        ), "Translation unit must have at least one exit node"
         return CFGTraversalResult(
             entry_node_id=first_entry,
             exit_node_ids=last_exits,
@@ -414,9 +414,9 @@ class CCFGVisitor(CFGVisitor):
         return_id = self.create_node(NodeType.RETURN, node, get_source_text(node))
 
         # Connect to function exit
-        assert len(self.cfg.exit_node_ids) > 0, (
-            "Return statement must have an exit node"
-        )
+        assert (
+            len(self.cfg.exit_node_ids) > 0
+        ), "Return statement must have an exit node"
         self.cfg.add_edge(return_id, self.cfg.exit_node_ids[-1])
 
         return CFGTraversalResult(

--- a/src/tree_climber/cfg/languages/java.py
+++ b/src/tree_climber/cfg/languages/java.py
@@ -158,12 +158,12 @@ class JavaCFGVisitor(CFGVisitor):
                     first_entry = result.entry_node_id
                 last_exits = result.exit_node_ids
 
-        assert first_entry is not None, (
-            "Translation unit must have at least one entry node"
-        )
-        assert last_exits is not None, (
-            "Translation unit must have at least one exit node"
-        )
+        assert (
+            first_entry is not None
+        ), "Translation unit must have at least one entry node"
+        assert (
+            last_exits is not None
+        ), "Translation unit must have at least one exit node"
         return CFGTraversalResult(
             entry_node_id=first_entry,
             exit_node_ids=last_exits,
@@ -514,9 +514,9 @@ class JavaCFGVisitor(CFGVisitor):
         return_id = self.create_node(NodeType.RETURN, node, get_source_text(node))
 
         # Connect to function exit
-        assert len(self.cfg.exit_node_ids) > 0, (
-            "Return statement must have an exit node"
-        )
+        assert (
+            len(self.cfg.exit_node_ids) > 0
+        ), "Return statement must have an exit node"
         self.cfg.add_edge(return_id, self.cfg.exit_node_ids[-1])
 
         # Return statements don't have normal successors

--- a/src/tree_climber/cfg/languages/java.py
+++ b/src/tree_climber/cfg/languages/java.py
@@ -630,7 +630,7 @@ def main():
     import os
     import sys
 
-    from tree_sitter_languages import get_parser
+    from tree_sitter_language_pack import get_parser
 
     from tree_climber.cfg.visualization import visualize_cfg
 

--- a/src/tree_climber/cfg/visitor.py
+++ b/src/tree_climber/cfg/visitor.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, List, Optional
 
 from tree_sitter import Node
 
-from tree_climber.ast_utils import (
-    get_source_text,
-)
+from tree_climber.ast_utils import get_source_text
 from tree_climber.cfg.cfg_types import (
     CFGNode,
     CFGNodeMetadata,
@@ -23,17 +21,17 @@ class ControlFlowContext:
         self.current_nodes: List[int] = []  # Current active nodes
         self.switch_heads: List[int] = []  # Stack of switch statement heads
         self.labels: Dict[str, int] = {}  # Map of label names to node IDs
-        self.forward_goto_refs: Dict[
-            str, List[int]
-        ] = {}  # Forward references to labels
+        self.forward_goto_refs: Dict[str, List[int]] = (
+            {}
+        )  # Forward references to labels
         self.entry_node_ids: List[int] = []  # Stack of entry node IDs
         self.exit_node_ids: List[int] = []  # Stack of exit node IDs
-        self.function_definitions: Dict[
-            int, str
-        ] = {}  # Map of entry node IDs to function names
-        self.function_call_exits: List[
-            tuple[int, int]
-        ] = []  # List of (function_exit_id, call_return_point_id) pairs
+        self.function_definitions: Dict[int, str] = (
+            {}
+        )  # Map of entry node IDs to function names
+        self.function_call_exits: List[tuple[int, int]] = (
+            []
+        )  # List of (function_exit_id, call_return_point_id) pairs
 
     def push_loop_context(self, break_target: int, continue_target: int):
         """Push a new loop context"""

--- a/src/tree_climber/cli/__init__.py
+++ b/src/tree_climber/cli/__init__.py
@@ -5,10 +5,7 @@ Command-line interface for program analysis and visualization.
 """
 
 from .commands import AnalysisOptions, analyze_source_code
-from .visualizers.constants import (
-    DEFAULT_LANGUAGE,
-    SUPPORTED_LANGUAGES,
-)
+from .visualizers.constants import DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES
 
 __all__ = [
     "analyze_source_code",

--- a/src/tree_climber/cli/visualizers/ast_visualizer.py
+++ b/src/tree_climber/cli/visualizers/ast_visualizer.py
@@ -3,9 +3,7 @@ from typing import override
 import pygraphviz as pgv
 from tree_sitter import Node
 
-from tree_climber.cli.visualizers.base_visualizer import (
-    BaseVisualizer,
-)
+from tree_climber.cli.visualizers.base_visualizer import BaseVisualizer
 from tree_climber.cli.visualizers.utils import ast_label
 
 from .constants import (

--- a/src/tree_climber/cli/visualizers/cfg_visualizer.py
+++ b/src/tree_climber/cli/visualizers/cfg_visualizer.py
@@ -9,9 +9,7 @@ from tree_climber.cli.visualizers.base_visualizer import (
 from tree_climber.cli.visualizers.dfg_visualizer import add_dfg_edge
 from tree_climber.cli.visualizers.utils import add_cfg_node
 
-from .constants import (
-    DEFAULT_DPI,
-)
+from .constants import DEFAULT_DPI
 
 
 class CFGVisualizer(BaseVisualizer):

--- a/src/tree_climber/cli/visualizers/dfg_visualizer.py
+++ b/src/tree_climber/cli/visualizers/dfg_visualizer.py
@@ -9,9 +9,7 @@ from tree_climber.cli.visualizers.base_visualizer import (
 )
 from tree_climber.cli.visualizers.utils import add_cfg_node, add_dfg_edge
 
-from .constants import (
-    DEFAULT_DPI,
-)
+from .constants import DEFAULT_DPI
 
 
 class DFGVisualizer(BaseVisualizer):

--- a/src/tree_climber/dataflow/analyses/def_use.py
+++ b/src/tree_climber/dataflow/analyses/def_use.py
@@ -2,9 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from tree_climber.cfg.visitor import CFG
-from tree_climber.dataflow.analyses.reaching_definitions import (
-    ReachingDefinition,
-)
+from tree_climber.dataflow.analyses.reaching_definitions import ReachingDefinition
 from tree_climber.dataflow.dataflow_types import DataflowResult
 
 

--- a/src/tree_climber/dataflow/analyses/reaching_definitions.py
+++ b/src/tree_climber/dataflow/analyses/reaching_definitions.py
@@ -42,9 +42,11 @@ def extract_function_call_arguments(ast_node: Node) -> List[str]:
                             # Look for identifiers within the argument expression
                             for identifier in dfs(
                                 arg_child,
-                                lambda n: get_source_text(n)
-                                if n.type == "identifier"
-                                else None,
+                                lambda n: (
+                                    get_source_text(n)
+                                    if n.type == "identifier"
+                                    else None
+                                ),
                             ):
                                 if identifier:
                                     arguments.append(identifier)

--- a/src/tree_climber/dataflow/analyses/use_def.py
+++ b/src/tree_climber/dataflow/analyses/use_def.py
@@ -2,9 +2,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 from tree_climber.cfg.visitor import CFG
-from tree_climber.dataflow.analyses.reaching_definitions import (
-    ReachingDefinition,
-)
+from tree_climber.dataflow.analyses.reaching_definitions import ReachingDefinition
 from tree_climber.dataflow.dataflow_types import DataflowResult
 
 

--- a/src/tree_climber/dataflow/main.py
+++ b/src/tree_climber/dataflow/main.py
@@ -1,4 +1,5 @@
-from tree_climber.dataflow.analyses.def_use import DefUseSolver, UseDefSolver
+from tree_climber.dataflow.analyses.def_use import DefUseSolver
+from tree_climber.dataflow.analyses.use_def import UseDefSolver
 from tree_climber.dataflow.analyses.reaching_definitions import (
     ReachingDefinitionsProblem,
 )

--- a/test/c_cfg/test_c_cfg.py
+++ b/test/c_cfg/test_c_cfg.py
@@ -28,9 +28,9 @@ class CFGTestHelper:
     def assert_node_count(self, cfg: CFG, expected_count: int, msg: str = ""):
         """Assert that CFG has the expected number of nodes."""
         actual_count = len(cfg.nodes)
-        assert actual_count == expected_count, (
-            f"Expected {expected_count} nodes, got {actual_count}. {msg}"
-        )
+        assert (
+            actual_count == expected_count
+        ), f"Expected {expected_count} nodes, got {actual_count}. {msg}"
 
     def assert_node_types(
         self, cfg: CFG, expected_types: Dict[NodeType, int], msg: str = ""
@@ -71,9 +71,9 @@ class CFGTestHelper:
         for (src_id, dest_id), expected_label in expected_labels.items():
             src_node = cfg.nodes.get(src_id)
             assert src_node is not None, f"Source node {src_id} not found. {msg}"
-            assert dest_id in src_node.successors, (
-                f"Edge {src_id}->{dest_id} not found. {msg}"
-            )
+            assert (
+                dest_id in src_node.successors
+            ), f"Edge {src_id}->{dest_id} not found. {msg}"
 
             actual_label = src_node.get_edge_label(dest_id)
             assert actual_label == expected_label, (
@@ -109,21 +109,21 @@ class CFGTestHelper:
         entry_nodes = self.get_entry_nodes(cfg)
         exit_nodes = self.get_exit_nodes(cfg)
 
-        assert len(entry_nodes) == 1, (
-            f"Expected 1 entry node, got {len(entry_nodes)}. {msg}"
-        )
-        assert len(exit_nodes) == 1, (
-            f"Expected 1 exit node, got {len(exit_nodes)}. {msg}"
-        )
+        assert (
+            len(entry_nodes) == 1
+        ), f"Expected 1 entry node, got {len(entry_nodes)}. {msg}"
+        assert (
+            len(exit_nodes) == 1
+        ), f"Expected 1 exit node, got {len(exit_nodes)}. {msg}"
 
         return entry_nodes[0], exit_nodes[0]
 
     def assert_reachable_from_entry(self, cfg: CFG, msg: str = ""):
         """Assert that all nodes are reachable from the entry node."""
         entry_nodes = self.get_entry_nodes(cfg)
-        assert len(entry_nodes) == 1, (
-            f"Expected 1 entry node for reachability test. {msg}"
-        )
+        assert (
+            len(entry_nodes) == 1
+        ), f"Expected 1 entry node for reachability test. {msg}"
 
         entry_node = entry_nodes[0]
         reachable = set()
@@ -147,9 +147,9 @@ class CFGTestHelper:
     def assert_exits_reach_function_exit(self, cfg: CFG, msg: str = ""):
         """Assert that all exit nodes can reach the function exit."""
         exit_nodes = self.get_exit_nodes(cfg)
-        assert len(exit_nodes) == 1, (
-            f"Expected 1 exit node for exit reachability test. {msg}"
-        )
+        assert (
+            len(exit_nodes) == 1
+        ), f"Expected 1 exit node for exit reachability test. {msg}"
 
         function_exit = exit_nodes[0]
 
@@ -162,9 +162,9 @@ class CFGTestHelper:
         # Check that these nodes have paths to function exit
         for node in nodes_with_exit_edges:
             if node.node_type == NodeType.RETURN:
-                assert function_exit.id in node.successors, (
-                    f"Return node {node.id} should connect to function exit. {msg}"
-                )
+                assert (
+                    function_exit.id in node.successors
+                ), f"Return node {node.id} should connect to function exit. {msg}"
 
 
 @pytest.fixture
@@ -800,14 +800,14 @@ class TestNestedConstructs:
         default_node = default_nodes[0]
 
         # Verify outer switch connects to default statement with "default" label
-        assert default_node.id in outer_switch.successors, (
-            "Outer switch should connect to default statement"
-        )
+        assert (
+            default_node.id in outer_switch.successors
+        ), "Outer switch should connect to default statement"
 
         default_edge_label = outer_switch.get_edge_label(default_node.id)
-        assert default_edge_label == "default", (
-            f"Expected 'default' label, got '{default_edge_label}'"
-        )
+        assert (
+            default_edge_label == "default"
+        ), f"Expected 'default' label, got '{default_edge_label}'"
 
 
 class TestComplexPatterns:
@@ -1182,16 +1182,16 @@ class TestCFGStructuralIntegrity:
             # Check successor relationships are bidirectional
             for successor_id in node.successors:
                 successor_node = cfg.nodes[successor_id]
-                assert node_id in successor_node.predecessors, (
-                    f"Node {successor_id} should have {node_id} as predecessor"
-                )
+                assert (
+                    node_id in successor_node.predecessors
+                ), f"Node {successor_id} should have {node_id} as predecessor"
 
             # Check predecessor relationships are bidirectional
             for predecessor_id in node.predecessors:
                 predecessor_node = cfg.nodes[predecessor_id]
-                assert node_id in predecessor_node.successors, (
-                    f"Node {predecessor_id} should have {node_id} as successor"
-                )
+                assert (
+                    node_id in predecessor_node.successors
+                ), f"Node {predecessor_id} should have {node_id} as successor"
 
     def test_edge_label_consistency(self, helper):
         """Test proper true/false edge labeling."""
@@ -1220,12 +1220,12 @@ class TestCFGStructuralIntegrity:
             if len(condition_node.successors) == 2:
                 # Should have both true and false labels
                 labels = set(edge_labels.values())
-                assert "true" in labels, (
-                    f"Condition node {condition_node.id} missing 'true' label"
-                )
-                assert "false" in labels, (
-                    f"Condition node {condition_node.id} missing 'false' label"
-                )
+                assert (
+                    "true" in labels
+                ), f"Condition node {condition_node.id} missing 'true' label"
+                assert (
+                    "false" in labels
+                ), f"Condition node {condition_node.id} missing 'false' label"
 
         # Check loop headers have proper edge labels
         loop_headers = helper.get_nodes_by_type(cfg, NodeType.LOOP_HEADER)
@@ -1233,12 +1233,12 @@ class TestCFGStructuralIntegrity:
             edge_labels = loop_header.edge_labels
             if len(loop_header.successors) >= 2:
                 labels = set(edge_labels.values())
-                assert "true" in labels, (
-                    f"Loop header {loop_header.id} missing 'true' label"
-                )
-                assert "false" in labels, (
-                    f"Loop header {loop_header.id} missing 'false' label"
-                )
+                assert (
+                    "true" in labels
+                ), f"Loop header {loop_header.id} missing 'true' label"
+                assert (
+                    "false" in labels
+                ), f"Loop header {loop_header.id} missing 'false' label"
 
 
 class TestVariableAnalysis:
@@ -1263,9 +1263,11 @@ class TestVariableAnalysis:
 
         # Should include variable definitions
         assert len(all_definitions) > 0, "Should track variable definitions"
-        assert set(all_definitions) == {"argc", "x", "y"}, (
-            "Should track variable definitions"
-        )
+        assert set(all_definitions) == {
+            "argc",
+            "x",
+            "y",
+        }, "Should track variable definitions"
 
     def test_variable_uses(self, helper):
         """Test variable use tracking."""
@@ -1347,30 +1349,30 @@ class TestVariableAnalysis:
         assert continuation_node is not None, "Should find continuation node"
 
         # Verify call edge: call_node -> helper_entry
-        assert helper_entry.id in call_node.successors, (
-            "Call node should have edge to function entry"
-        )
+        assert (
+            helper_entry.id in call_node.successors
+        ), "Call node should have edge to function entry"
 
         # Verify return edge: helper_exit -> call_node
-        assert call_node.id in helper_exit.successors, (
-            "Function exit should have edge back to call node"
-        )
+        assert (
+            call_node.id in helper_exit.successors
+        ), "Function exit should have edge back to call node"
 
         # Verify continuation edge: call_node -> continuation_node
-        assert continuation_node.id in call_node.successors, (
-            "Call node should have edge to continuation"
-        )
+        assert (
+            continuation_node.id in call_node.successors
+        ), "Call node should have edge to continuation"
 
         # Verify edge labels
         call_edge_label = call_node.get_edge_label(helper_entry.id)
         return_edge_label = helper_exit.get_edge_label(call_node.id)
 
-        assert call_edge_label == "function_call", (
-            f"Call edge should be labeled 'function_call', got {call_edge_label}"
-        )
-        assert return_edge_label == "function_return", (
-            f"Return edge should be labeled 'function_return', got {return_edge_label}"
-        )
+        assert (
+            call_edge_label == "function_call"
+        ), f"Call edge should be labeled 'function_call', got {call_edge_label}"
+        assert (
+            return_edge_label == "function_return"
+        ), f"Return edge should be labeled 'function_return', got {return_edge_label}"
 
     def test_multiple_function_calls(self, helper):
         """Test multiple function calls in sequence."""
@@ -1405,9 +1407,9 @@ class TestVariableAnalysis:
         assert func2_call is not None, "Should find func2 call"
 
         # Verify calls are connected in sequence
-        assert func2_call.id in func1_call.successors, (
-            "First call should connect to second call"
-        )
+        assert (
+            func2_call.id in func1_call.successors
+        ), "First call should connect to second call"
 
         # Verify each call has proper call and return edges
         func1_call_edges = [
@@ -1455,12 +1457,12 @@ class TestVariableAnalysis:
                     return_edge_count += 1
 
         # Should have call edges for intermediate() and leaf() calls
-        assert call_edge_count >= 2, (
-            f"Should have at least 2 function call edges, got {call_edge_count}"
-        )
-        assert return_edge_count >= 2, (
-            f"Should have at least 2 function return edges, got {return_edge_count}"
-        )
+        assert (
+            call_edge_count >= 2
+        ), f"Should have at least 2 function call edges, got {call_edge_count}"
+        assert (
+            return_edge_count >= 2
+        ), f"Should have at least 2 function return edges, got {return_edge_count}"
 
 
 if __name__ == "__main__":

--- a/test/dfg/test_dfg_comprehensive.py
+++ b/test/dfg/test_dfg_comprehensive.py
@@ -11,7 +11,8 @@ import pytest
 
 from tree_climber.cfg.builder import CFGBuilder
 from tree_climber.cfg.visitor import CFG
-from tree_climber.dataflow.analyses.def_use import DefUseSolver, UseDefSolver
+from tree_climber.dataflow.analyses.def_use import DefUseSolver
+from tree_climber.dataflow.analyses.use_def import UseDefSolver
 from tree_climber.dataflow.analyses.reaching_definitions import (
     ReachingDefinitionsProblem,
 )

--- a/test/dfg/test_dfg_comprehensive.py
+++ b/test/dfg/test_dfg_comprehensive.py
@@ -372,9 +372,9 @@ class TestBasicDefUse:
 
         # x should have two definitions with different uses
         x_chains = def_use_result.chains.get("x", [])
-        assert len(x_chains) == 2, (
-            f"Expected 2 def-use chains for x, got {len(x_chains)}"
-        )
+        assert (
+            len(x_chains) == 2
+        ), f"Expected 2 def-use chains for x, got {len(x_chains)}"
 
         # First definition (x = 5) should reach y assignment
         helper.assert_def_use_chain(
@@ -429,13 +429,13 @@ class TestBasicDefUse:
                 y_assignment_chain = chain
                 break
 
-        assert y_assignment_chain is not None, (
-            "Should find use-def chain for x in y assignment"
-        )
+        assert (
+            y_assignment_chain is not None
+        ), "Should find use-def chain for x in y assignment"
         # Should have definitions from both conditional branches
-        assert len(y_assignment_chain.definitions) >= 1, (
-            "x use should have at least one reaching definition"
-        )
+        assert (
+            len(y_assignment_chain.definitions) >= 1
+        ), "x use should have at least one reaching definition"
 
 
 class TestInterproceduralAnalysis:
@@ -624,9 +624,9 @@ class TestIncrementOperators:
 
         # a++ should create a def-use chain where the increment definition points to itself
         a_chains = def_use_result.chains.get("a", [])
-        assert len(a_chains) >= 1, (
-            f"Expected at least 1 def-use chain for a, got {len(a_chains)}"
-        )
+        assert (
+            len(a_chains) >= 1
+        ), f"Expected at least 1 def-use chain for a, got {len(a_chains)}"
 
         # Look for the increment chain that should point to itself
         increment_chain = None
@@ -637,17 +637,17 @@ class TestIncrementOperators:
                 increment_chain = chain
                 break
 
-        assert increment_chain is not None, (
-            "Should find def-use chain for a++ increment"
-        )
+        assert (
+            increment_chain is not None
+        ), "Should find def-use chain for a++ increment"
 
         # The increment should point to its own use (self-reference)
         # For C: a++ should point to itself AND to uses of a
         # For Java: a++ should point to itself
         increment_def_id = increment_chain.definition
-        assert increment_def_id in increment_chain.uses, (
-            "a++ should have a self-reference (definition should be in its own uses)"
-        )
+        assert (
+            increment_def_id in increment_chain.uses
+        ), "a++ should have a self-reference (definition should be in its own uses)"
 
     def test_prefix_increment_self_reference(self, helper):
         """Test that ++a should point to itself in def-use chains."""
@@ -679,9 +679,9 @@ class TestIncrementOperators:
 
         # ++a should create a def-use chain where the increment definition points to itself
         a_chains = def_use_result.chains.get("a", [])
-        assert len(a_chains) >= 1, (
-            f"Expected at least 1 def-use chain for a, got {len(a_chains)}"
-        )
+        assert (
+            len(a_chains) >= 1
+        ), f"Expected at least 1 def-use chain for a, got {len(a_chains)}"
 
         # Look for the increment chain
         increment_chain = None
@@ -692,15 +692,15 @@ class TestIncrementOperators:
                 increment_chain = chain
                 break
 
-        assert increment_chain is not None, (
-            "Should find def-use chain for ++a increment"
-        )
+        assert (
+            increment_chain is not None
+        ), "Should find def-use chain for ++a increment"
 
         # The increment should point to its own use (self-reference)
         increment_def_id = increment_chain.definition
-        assert increment_def_id in increment_chain.uses, (
-            "++a should have a self-reference"
-        )
+        assert (
+            increment_def_id in increment_chain.uses
+        ), "++a should have a self-reference"
 
     def test_increment_in_expression(self, helper):
         """Test increment operators within expressions."""
@@ -752,9 +752,9 @@ class TestIncrementOperators:
                 break
 
         assert increment_chain is not None, "Should find def-use chain for increment"
-        assert increment_node in increment_chain.uses, (
-            "a++ should have self-reference even in expressions"
-        )
+        assert (
+            increment_node in increment_chain.uses
+        ), "a++ should have self-reference even in expressions"
 
     def test_multiple_increments(self, helper):
         """Test multiple increment operations on the same variable."""
@@ -790,9 +790,9 @@ class TestIncrementOperators:
 
         # Should have multiple def-use chains for a
         a_chains = def_use_result.chains.get("a", [])
-        assert len(a_chains) >= 3, (
-            f"Expected at least 3 def-use chains for a (initial + increments), got {len(a_chains)}"
-        )
+        assert (
+            len(a_chains) >= 3
+        ), f"Expected at least 3 def-use chains for a (initial + increments), got {len(a_chains)}"
 
         # Each increment/decrement should have self-reference
         increment_chains = []
@@ -802,16 +802,16 @@ class TestIncrementOperators:
             if "++" in def_text or "--" in def_text:
                 increment_chains.append(chain)
 
-        assert len(increment_chains) >= 3, (
-            f"Expected at least 3 increment/decrement chains, got {len(increment_chains)}"
-        )
+        assert (
+            len(increment_chains) >= 3
+        ), f"Expected at least 3 increment/decrement chains, got {len(increment_chains)}"
 
         # Each increment chain should have self-reference
         for chain in increment_chains:
             increment_def_id = chain.definition
-            assert increment_def_id in chain.uses, (
-                f"Increment/decrement at node {increment_def_id} should have self-reference"
-            )
+            assert (
+                increment_def_id in chain.uses
+            ), f"Increment/decrement at node {increment_def_id} should have self-reference"
 
 
 class TestComplexDataflow:
@@ -857,15 +857,15 @@ class TestComplexDataflow:
 
         # sum should have multiple definitions due to loop
         sum_chains = def_use_result.chains.get("sum", [])
-        assert len(sum_chains) >= 2, (
-            f"Expected at least 2 def-use chains for sum, got {len(sum_chains)}"
-        )
+        assert (
+            len(sum_chains) >= 2
+        ), f"Expected at least 2 def-use chains for sum, got {len(sum_chains)}"
 
         # Parameter 'val' should be aliased to loop variable 'i'
         val_chains = def_use_result.chains.get("val", [])
-        assert len(val_chains) >= 1, (
-            f"Expected at least 1 def-use chain for val, got {len(val_chains)}"
-        )
+        assert (
+            len(val_chains) >= 1
+        ), f"Expected at least 1 def-use chain for val, got {len(val_chains)}"
 
     def test_parameter_modification(self, helper):
         """Test when parameters are modified within functions."""
@@ -901,9 +901,9 @@ class TestComplexDataflow:
 
         # Parameter 'p' should have multiple definitions
         p_chains = def_use_result.chains.get("p", [])
-        assert len(p_chains) >= 2, (
-            f"Expected at least 2 def-use chains for p, got {len(p_chains)}"
-        )
+        assert (
+            len(p_chains) >= 2
+        ), f"Expected at least 2 def-use chains for p, got {len(p_chains)}"
 
         # Original parameter should alias to argument
         helper.assert_parameter_alias(
@@ -960,9 +960,9 @@ class TestComplexDataflow:
                 b_assignment_chain = chain
                 break
 
-        assert b_assignment_chain is not None, (
-            "Should find use-def chain for 'a' in 'b = a + 1'"
-        )
+        assert (
+            b_assignment_chain is not None
+        ), "Should find use-def chain for 'a' in 'b = a + 1'"
 
         # The use of 'a' in "int b = a + 1" should ONLY reach the definition "a = 10"
         # It should NOT reach the original argument definition "x = 5"
@@ -973,12 +973,12 @@ class TestComplexDataflow:
                 reaching_defs.append(def_node.source_text.strip())
 
         # Should only have "a = 10" as reaching definition, not "x = 5"
-        assert any("a = 10" in def_text for def_text in reaching_defs), (
-            "Should have 'a = 10' as reaching definition"
-        )
-        assert not any("x = 5" in def_text for def_text in reaching_defs), (
-            f"Should NOT have 'x = 5' as reaching definition. Found: {reaching_defs}"
-        )
+        assert any(
+            "a = 10" in def_text for def_text in reaching_defs
+        ), "Should have 'a = 10' as reaching definition"
+        assert not any(
+            "x = 5" in def_text for def_text in reaching_defs
+        ), f"Should NOT have 'x = 5' as reaching definition. Found: {reaching_defs}"
 
 
 if __name__ == "__main__":

--- a/test/dfg/test_dfg_stress.py
+++ b/test/dfg/test_dfg_stress.py
@@ -6,8 +6,9 @@ using the stress test programs in C and Java.
 """
 
 import os
-import pytest
 from test.dfg.test_dfg_comprehensive import DFGTestHelper
+
+import pytest
 
 
 class TestDFGStressC:
@@ -80,9 +81,9 @@ class TestDFGStressC:
 
         # Parameter x should have multiple definitions
         x_chains = def_use_result.chains.get("x", [])
-        assert len(x_chains) >= 2, (
-            f"Expected at least 2 def-use chains for x, got {len(x_chains)}"
-        )
+        assert (
+            len(x_chains) >= 2
+        ), f"Expected at least 2 def-use chains for x, got {len(x_chains)}"
 
         # Original parameter should alias to argument
         self.helper.assert_parameter_alias(
@@ -158,9 +159,9 @@ class TestDFGStressC:
 
         # sum should have multiple definitions due to loop
         sum_chains = def_use_result.chains.get("sum", [])
-        assert len(sum_chains) >= 2, (
-            f"Expected at least 2 def-use chains for sum, got {len(sum_chains)}"
-        )
+        assert (
+            len(sum_chains) >= 2
+        ), f"Expected at least 2 def-use chains for sum, got {len(sum_chains)}"
 
         # Loop variable i should be aliased to parameter x
         self.helper.assert_parameter_alias(
@@ -208,9 +209,9 @@ class TestDFGStressC:
 
         # result should have multiple definitions
         result_chains = def_use_result.chains.get("result", [])
-        assert len(result_chains) >= 2, (
-            f"Expected multiple def-use chains for result, got {len(result_chains)}"
-        )
+        assert (
+            len(result_chains) >= 2
+        ), f"Expected multiple def-use chains for result, got {len(result_chains)}"
 
 
 class TestDFGStressJava:
@@ -279,9 +280,9 @@ class TestDFGStressJava:
 
         # Enhanced for loop should create proper dataflow
         sum_chains = def_use_result.chains.get("sum", [])
-        assert len(sum_chains) >= 1, (
-            f"Expected at least 1 def-use chain for sum, got {len(sum_chains)}"
-        )
+        assert (
+            len(sum_chains) >= 1
+        ), f"Expected at least 1 def-use chain for sum, got {len(sum_chains)}"
 
         # Parameter x should be aliased to loop variable num
         self.helper.assert_parameter_alias(
@@ -326,9 +327,9 @@ class TestDFGStressJava:
 
         # result should have definitions from both try and catch blocks
         result_chains = def_use_result.chains.get("result", [])
-        assert len(result_chains) >= 2, (
-            f"Expected multiple def-use chains for result, got {len(result_chains)}"
-        )
+        assert (
+            len(result_chains) >= 2
+        ), f"Expected multiple def-use chains for result, got {len(result_chains)}"
 
     def test_switch_with_method_calls(self):
         """Test DFG analysis with switch statements containing method calls."""
@@ -373,9 +374,9 @@ class TestDFGStressJava:
 
         # result should have multiple possible definitions
         result_chains = def_use_result.chains.get("result", [])
-        assert len(result_chains) >= 1, (
-            f"Expected at least 1 def-use chain for result, got {len(result_chains)}"
-        )
+        assert (
+            len(result_chains) >= 1
+        ), f"Expected at least 1 def-use chain for result, got {len(result_chains)}"
 
     def test_recursive_methods(self):
         """Test DFG analysis with recursive method calls."""
@@ -408,9 +409,9 @@ class TestDFGStressJava:
 
         # n should be used in multiple places within the recursive method
         n_chains = def_use_result.chains.get("n", [])
-        assert len(n_chains) >= 1, (
-            f"Expected at least 1 def-use chain for n, got {len(n_chains)}"
-        )
+        assert (
+            len(n_chains) >= 1
+        ), f"Expected at least 1 def-use chain for n, got {len(n_chains)}"
 
 
 class TestDFGEdgeCases:
@@ -447,9 +448,9 @@ class TestDFGEdgeCases:
         cfg, def_use_result, use_def_result = self.helper.build_dfg_from_code(code)
 
         # Should handle empty functions gracefully
-        assert len(def_use_result.chains) >= 0, (
-            "Should handle empty functions without error"
-        )
+        assert (
+            len(def_use_result.chains) >= 0
+        ), "Should handle empty functions without error"
 
     def test_functions_with_no_parameters(self, helper):
         """Test functions that have no parameters."""

--- a/test/java_cfg/test_java_cfg.py
+++ b/test/java_cfg/test_java_cfg.py
@@ -18,10 +18,11 @@ Created: 2025-08-14
 Author: Claude Code Assistant
 """
 
-import pytest
-from typing import List, Dict, Set, Optional, Tuple
-import tempfile
 import os
+import tempfile
+from typing import Dict, List, Optional, Set, Tuple
+
+import pytest
 
 from tree_climber.cfg.builder import CFGBuilder
 from tree_climber.cfg.cfg_types import NodeType
@@ -118,15 +119,15 @@ public class TestClass {{
 
         # Check that entry nodes are in the CFG's entry list
         for entry_node in entry_nodes:
-            assert entry_node.id in cfg.entry_node_ids, (
-                f"Entry node {entry_node.id} not in CFG entry list. {message}"
-            )
+            assert (
+                entry_node.id in cfg.entry_node_ids
+            ), f"Entry node {entry_node.id} not in CFG entry list. {message}"
 
         # Check that exit nodes are in the CFG's exit list
         for exit_node in exit_nodes:
-            assert exit_node.id in cfg.exit_node_ids, (
-                f"Exit node {exit_node.id} not in CFG exit list. {message}"
-            )
+            assert (
+                exit_node.id in cfg.exit_node_ids
+            ), f"Exit node {exit_node.id} not in CFG exit list. {message}"
 
     def assert_edge_connections(
         self,
@@ -150,12 +151,12 @@ public class TestClass {{
                     n for n in cfg.nodes.values() if to_node_text in n.source_text
                 ]
 
-            assert len(from_nodes) > 0, (
-                f"Source node containing '{from_node_text}' not found. {message}"
-            )
-            assert len(to_nodes) > 0, (
-                f"Target node containing '{to_node_text}' not found. {message}"
-            )
+            assert (
+                len(from_nodes) > 0
+            ), f"Source node containing '{from_node_text}' not found. {message}"
+            assert (
+                len(to_nodes) > 0
+            ), f"Target node containing '{to_node_text}' not found. {message}"
 
             from_node = from_nodes[0]
             to_node = to_nodes[0]
@@ -167,9 +168,9 @@ public class TestClass {{
 
             if expected_label is not None:
                 actual_label = from_node.get_edge_label(to_node.id)
-                assert actual_label == expected_label, (
-                    f"Expected edge label '{expected_label}', got '{actual_label}'. {message}"
-                )
+                assert (
+                    actual_label == expected_label
+                ), f"Expected edge label '{expected_label}', got '{actual_label}'. {message}"
 
     def assert_reachability(self, cfg: CFG, message: str = ""):
         """Assert all nodes are reachable from entry nodes."""
@@ -209,16 +210,16 @@ public class TestClass {{
     ):
         """Assert method parameters are correctly extracted."""
         entry_nodes = [n for n in cfg.nodes.values() if n.node_type == NodeType.ENTRY]
-        assert len(entry_nodes) > 0, (
-            f"No entry node found for parameter validation. {message}"
-        )
+        assert (
+            len(entry_nodes) > 0
+        ), f"No entry node found for parameter validation. {message}"
 
         entry_node = entry_nodes[0]
         actual_parameters = entry_node.metadata.variable_definitions
 
-        assert actual_parameters == expected_parameters, (
-            f"Expected parameters {expected_parameters}, got {actual_parameters}. {message}"
-        )
+        assert (
+            actual_parameters == expected_parameters
+        ), f"Expected parameters {expected_parameters}, got {actual_parameters}. {message}"
 
     def assert_variable_tracking(
         self,
@@ -240,9 +241,9 @@ public class TestClass {{
         missing_uses = expected_uses - all_uses
         extra_uses = all_uses - expected_uses
 
-        assert not missing_definitions, (
-            f"Missing variable definitions: {missing_definitions}. {message}"
-        )
+        assert (
+            not missing_definitions
+        ), f"Missing variable definitions: {missing_definitions}. {message}"
         assert not missing_uses, f"Missing variable uses: {missing_uses}. {message}"
 
         # Extra definitions/uses are warnings, not errors
@@ -618,30 +619,30 @@ class TestObjectOriented:
         assert continuation_node is not None, "Should find continuation node"
 
         # Verify call edge: call_node -> helper_entry
-        assert helper_entry.id in call_node.successors, (
-            "Call node should have edge to method entry"
-        )
+        assert (
+            helper_entry.id in call_node.successors
+        ), "Call node should have edge to method entry"
 
         # Verify return edge: helper_exit -> call_node
-        assert call_node.id in helper_exit.successors, (
-            "Method exit should have edge back to call node"
-        )
+        assert (
+            call_node.id in helper_exit.successors
+        ), "Method exit should have edge back to call node"
 
         # Verify continuation edge: call_node -> continuation_node
-        assert continuation_node.id in call_node.successors, (
-            "Call node should have edge to continuation"
-        )
+        assert (
+            continuation_node.id in call_node.successors
+        ), "Call node should have edge to continuation"
 
         # Verify edge labels
         call_edge_label = call_node.get_edge_label(helper_entry.id)
         return_edge_label = helper_exit.get_edge_label(call_node.id)
 
-        assert call_edge_label == "function_call", (
-            f"Call edge should be labeled 'function_call', got {call_edge_label}"
-        )
-        assert return_edge_label == "function_return", (
-            f"Return edge should be labeled 'function_return', got {return_edge_label}"
-        )
+        assert (
+            call_edge_label == "function_call"
+        ), f"Call edge should be labeled 'function_call', got {call_edge_label}"
+        assert (
+            return_edge_label == "function_return"
+        ), f"Return edge should be labeled 'function_return', got {return_edge_label}"
 
     def test_multiple_method_calls(self):
         """Test multiple method calls in sequence."""
@@ -677,9 +678,9 @@ class TestObjectOriented:
         assert method2_call is not None, "Should find method2 call"
 
         # Verify calls are connected in sequence
-        assert method2_call.id in method1_call.successors, (
-            "First call should connect to second call"
-        )
+        assert (
+            method2_call.id in method1_call.successors
+        ), "First call should connect to second call"
 
         # Verify each call has proper call and return edges
         method1_call_edges = [
@@ -693,12 +694,12 @@ class TestObjectOriented:
             if label == "function_call"
         ]
 
-        assert len(method1_call_edges) > 0, (
-            "method1 call should have function_call edge"
-        )
-        assert len(method2_call_edges) > 0, (
-            "method2 call should have function_call edge"
-        )
+        assert (
+            len(method1_call_edges) > 0
+        ), "method1 call should have function_call edge"
+        assert (
+            len(method2_call_edges) > 0
+        ), "method2 call should have function_call edge"
 
     def test_nested_method_calls(self):
         """Test method calls within other methods."""
@@ -732,12 +733,12 @@ class TestObjectOriented:
                     return_edge_count += 1
 
         # Should have call edges for intermediate() and leaf() calls
-        assert call_edge_count >= 2, (
-            f"Should have at least 2 function call edges, got {call_edge_count}"
-        )
-        assert return_edge_count >= 2, (
-            f"Should have at least 2 function return edges, got {return_edge_count}"
-        )
+        assert (
+            call_edge_count >= 2
+        ), f"Should have at least 2 function call edges, got {call_edge_count}"
+        assert (
+            return_edge_count >= 2
+        ), f"Should have at least 2 function return edges, got {return_edge_count}"
 
 
 class TestJavaSpecific:
@@ -791,9 +792,9 @@ class TestNestedConstructs:
         loop_headers = [
             n for n in cfg.nodes.values() if n.node_type == NodeType.LOOP_HEADER
         ]
-        assert len(loop_headers) >= 2, (
-            "Should have multiple loop headers for nested loops"
-        )
+        assert (
+            len(loop_headers) >= 2
+        ), "Should have multiple loop headers for nested loops"
         self.helper.assert_reachability(cfg)
 
     def test_nested_switch_statements(self):
@@ -806,9 +807,9 @@ class TestNestedConstructs:
         switch_heads = [
             n for n in cfg.nodes.values() if n.node_type == NodeType.SWITCH_HEAD
         ]
-        assert len(switch_heads) >= 2, (
-            "Should have multiple switch heads for nested switches"
-        )
+        assert (
+            len(switch_heads) >= 2
+        ), "Should have multiple switch heads for nested switches"
         self.helper.assert_reachability(cfg)
 
 
@@ -876,9 +877,9 @@ class TestCFGStructuralIntegrity:
                 for successor_id in node.successors:
                     if successor_id in cfg.nodes:
                         successor_node = cfg.nodes[successor_id]
-                        assert node_id in successor_node.predecessors, (
-                            f"Inconsistent edge: {node_id}->{successor_id} missing reverse edge"
-                        )
+                        assert (
+                            node_id in successor_node.predecessors
+                        ), f"Inconsistent edge: {node_id}->{successor_id} missing reverse edge"
 
 
 class TestVariableAnalysis:
@@ -904,9 +905,9 @@ class TestVariableAnalysis:
         # Should include local variable definitions
         expected_vars = {"a", "b", "c"}
         found_vars = all_definitions & expected_vars
-        assert len(found_vars) > 0, (
-            f"Should track some variable definitions, got: {all_definitions}"
-        )
+        assert (
+            len(found_vars) > 0
+        ), f"Should track some variable definitions, got: {all_definitions}"
 
     def test_parameter_tracking(self):
         """Test method parameter tracking in entry nodes."""

--- a/test/oneoff/debug_ast_structure.py
+++ b/test/oneoff/debug_ast_structure.py
@@ -9,7 +9,7 @@ parsed and visited by examining the AST structure.
 Investigation: Walk through the AST to understand the switch statement structure.
 """
 
-from tree_climber.ast_utils import parse_source_to_ast, get_source_text
+from tree_climber.ast_utils import get_source_text, parse_source_to_ast
 
 
 def print_ast_structure(node, indent=0, max_depth=15):

--- a/test/oneoff/debug_dfg_parameter_alias.py
+++ b/test/oneoff/debug_dfg_parameter_alias.py
@@ -9,10 +9,11 @@ to understand what needs to be fixed for the parsing bug:
 import os
 import tempfile
 
-from tree_sitter_languages import get_parser
+from tree_sitter_language_pack import get_parser
 
 from tree_climber.cfg.builder import CFGBuilder
-from tree_climber.dataflow.analyses.def_use import DefUseSolver, UseDefSolver
+from tree_climber.dataflow.analyses.def_use import DefUseSolver
+from tree_climber.dataflow.analyses.use_def import UseDefSolver
 from tree_climber.dataflow.analyses.reaching_definitions import (
     ReachingDefinitionsProblem,
 )

--- a/test/oneoff/debug_dfg_parameter_alias.py
+++ b/test/oneoff/debug_dfg_parameter_alias.py
@@ -6,9 +6,11 @@ to understand what needs to be fixed for the parsing bug:
 "Both languages DFG, Function parameters should alias def uses"
 """
 
-import tempfile
 import os
+import tempfile
+
 from tree_sitter_languages import get_parser
+
 from tree_climber.cfg.builder import CFGBuilder
 from tree_climber.dataflow.analyses.def_use import DefUseSolver, UseDefSolver
 from tree_climber.dataflow.analyses.reaching_definitions import (

--- a/test/oneoff/debug_function_call_cfg.py
+++ b/test/oneoff/debug_function_call_cfg.py
@@ -6,11 +6,13 @@ to understand what needs to be fixed for the first parsing bug:
 "Both languages CFG, Function calls should have an edge from exit going back to the call"
 """
 
-import tempfile
 import os
+import tempfile
+
 from tree_sitter_languages import get_parser
-from tree_climber.cfg.languages.java import JavaCFGVisitor
+
 from tree_climber.cfg.languages.c import CCFGVisitor
+from tree_climber.cfg.languages.java import JavaCFGVisitor
 
 # Simple Java test with function call
 java_code = """

--- a/test/oneoff/debug_function_call_cfg.py
+++ b/test/oneoff/debug_function_call_cfg.py
@@ -9,7 +9,7 @@ to understand what needs to be fixed for the first parsing bug:
 import os
 import tempfile
 
-from tree_sitter_languages import get_parser
+from tree_sitter_language_pack import get_parser
 
 from tree_climber.cfg.languages.c import CCFGVisitor
 from tree_climber.cfg.languages.java import JavaCFGVisitor

--- a/test/oneoff/debug_interprocedural_alias.py
+++ b/test/oneoff/debug_interprocedural_alias.py
@@ -6,7 +6,8 @@ where function arguments should alias to parameters within the called function.
 """
 
 from tree_climber.cfg.builder import CFGBuilder
-from tree_climber.dataflow.analyses.def_use import DefUseSolver, UseDefSolver
+from tree_climber.dataflow.analyses.def_use import DefUseSolver
+from tree_climber.dataflow.analyses.use_def import UseDefSolver
 from tree_climber.dataflow.analyses.reaching_definitions import (
     ReachingDefinitionsProblem,
 )

--- a/test/oneoff/debug_parameter_ast_detailed.py
+++ b/test/oneoff/debug_parameter_ast_detailed.py
@@ -11,10 +11,10 @@ to understand how to correctly extract parameter names.
 """
 
 from tree_climber.ast_utils import (
-    parse_source_to_ast,
-    get_source_text,
-    get_required_child_by_field_name,
     get_child_by_field_name,
+    get_required_child_by_field_name,
+    get_source_text,
+    parse_source_to_ast,
 )
 
 

--- a/test/oneoff/debug_parameter_extraction.py
+++ b/test/oneoff/debug_parameter_extraction.py
@@ -14,7 +14,7 @@ correct AST structure for parameter_declaration nodes.
 Investigation: Examine AST structure and fix parameter extraction logic.
 """
 
-from tree_climber.ast_utils import parse_source_to_ast, get_source_text
+from tree_climber.ast_utils import get_source_text, parse_source_to_ast
 from tree_climber.cfg.builder import CFGBuilder
 
 

--- a/test/oneoff/debug_switch_case_creation.py
+++ b/test/oneoff/debug_switch_case_creation.py
@@ -10,9 +10,9 @@ Investigation: Examine the CFG before and after post-processing to see
 exactly where the default case connection is being lost.
 """
 
+from tree_climber.ast_utils import parse_source_to_ast
 from tree_climber.cfg.builder import CFGBuilder
 from tree_climber.cfg.languages.c import CCFGVisitor
-from tree_climber.ast_utils import parse_source_to_ast
 
 
 def debug_switch_before_postprocessing():

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.4, <3.13"
 
 [[package]]
@@ -51,6 +51,26 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/49/26a7b0f3f35da4b5a65f081943b7bcd22d7002f5f0fb8098ec1ff21cb6ef/black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666", size = 649449, upload-time = "2025-01-29T04:15:40.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/71/3fe4741df7adf015ad8dfa082dd36c94ca86bb21f25608eb247b4afb15b2/black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b", size = 1650988, upload-time = "2025-01-29T05:37:16.707Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f3/89aac8a83d73937ccd39bbe8fc6ac8860c11cfa0af5b1c96d081facac844/black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc", size = 1453985, upload-time = "2025-01-29T05:37:18.273Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/22/b99efca33f1f3a1d2552c714b1e1b5ae92efac6c43e790ad539a163d1754/black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f", size = 1783816, upload-time = "2025-01-29T04:18:33.823Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/a27c3ad3822b6f2e0e00d63d58ff6299a99a5b3aee69fa77cd4b0076b261/black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba", size = 1440860, upload-time = "2025-01-29T04:19:12.944Z" },
+    { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -75,6 +95,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
@@ -164,6 +193,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.13"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +222,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/64/ec0788201b5554e2a87c49af26b77a4d132f807a0fa9675257ac92c6aa0e/fastapi-0.115.13.tar.gz", hash = "sha256:55d1d25c2e1e0a0a50aceb1c8705cd932def273c102bff0b1c1da88b3c6eb307", size = 295680, upload-time = "2025-06-17T11:49:45.575Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/4a/e17764385382062b0edbb35a26b7cf76d71e27e456546277a42ba6545c6e/fastapi-0.115.13-py3-none-any.whl", hash = "sha256:0a0cab59afa7bab22f5eb347f8c9864b681558c278395e94035a741fc10cd865", size = 95315, upload-time = "2025-06-17T11:49:44.106Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
 ]
 
 [[package]]
@@ -237,6 +293,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ca/ffbabe3635bb839aa36b3a893c91a9b0d368cb4d8073e03a12896970af82/identify-2.6.13.tar.gz", hash = "sha256:da8d6c828e773620e13bfa86ea601c5a5310ba4bcd65edf378198b56a1f9fb32", size = 99243, upload-time = "2025-08-09T19:35:00.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl", hash = "sha256:60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b", size = 99153, upload-time = "2025-08-09T19:34:59.1Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -252,6 +317,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/21/1e2a441f74a653a144224d7d21afe8f4169e6c7c20bb13aec3a2dc3815e0/isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450", size = 821955, upload-time = "2025-02-26T21:13:16.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/11/114d0a5f4dabbdcedc1125dee0888514c3c3b16d3e9facad87ed96fad97c/isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615", size = 94186, upload-time = "2025-02-26T21:13:14.911Z" },
 ]
 
 [[package]]
@@ -381,6 +455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "narwhals"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -457,6 +540,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "11.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -476,12 +568,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
 ]
 
 [[package]]
@@ -634,6 +751,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -652,6 +782,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
 ]
 
 [[package]]
@@ -753,15 +900,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/1c/20cdb593783f8f411839ce749ec9ae9e4298c2b2079b40295c3e6e2089e1/ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245", size = 10519495, upload-time = "2025-06-26T20:34:08.718Z" },
     { url = "https://files.pythonhosted.org/packages/cf/56/7158bd8d3cf16394928f47c637d39a7d532268cd45220bdb6cd622985760/ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013", size = 11547485, upload-time = "2025-06-26T20:34:11.008Z" },
     { url = "https://files.pythonhosted.org/packages/91/d0/6902c0d017259439d6fd2fd9393cea1cfe30169940118b007d5e0ea7e954/ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc", size = 10691209, upload-time = "2025-06-26T20:34:12.928Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]
@@ -909,14 +1047,18 @@ dependencies = [
     { name = "streamlit" },
     { name = "streamlit-agraph" },
     { name = "tree-sitter" },
-    { name = "tree-sitter-languages" },
+    { name = "tree-sitter-language-pack" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "pre-commit" },
     { name = "pyright" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -933,56 +1075,98 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "streamlit", specifier = ">=1.46.0" },
     { name = "streamlit-agraph", specifier = ">=0.0.45" },
-    { name = "tree-sitter", specifier = "<0.21.0" },
-    { name = "tree-sitter-languages", specifier = ">=1.10.2" },
+    { name = "tree-sitter", specifier = ">=0.22.0" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.9.0" },
     { name = "typer", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.24.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "pre-commit" },
     { name = "pyright", specifier = ">=1.1.402" },
+    { name = "pytest-xdist" },
     { name = "ruff", specifier = ">=0.12.1" },
 ]
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.4"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/64/71b3a0ff7d0d89cb333caeca01992099c165bdd663e7990ea723615e60f4/tree_sitter-0.20.4.tar.gz", hash = "sha256:6adb123e2f3e56399bbf2359924633c882cc40ee8344885200bca0922f713be5", size = 140726, upload-time = "2023-11-13T06:43:08.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/2b/02a642e67605b9dd59986b00d13a076044dede04025a243f0592ac79d68c/tree-sitter-0.25.1.tar.gz", hash = "sha256:cd761ad0e4d1fc88a4b1b8083bae06d4f973acf6f5f29bbf13ea9609c1dec9c1", size = 177874, upload-time = "2025-08-05T17:14:34.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/17/cd3fe4ea74a33a1737e42cab20dc48f13b7fc855af99301d43679bc124ac/tree_sitter-0.20.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:c4c1af5ed4306071d30970c83ec882520a7bf5d8053996dbc4aa5c59238d4990", size = 257380, upload-time = "2023-11-13T06:41:34.115Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/e3/e028aab9e571646f1e8b5b4297f41a90d88f2b6c275989053d2d73a588aa/tree_sitter-0.20.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9d70bfa550cf22c9cea9b3c0d18b889fc4f2a7e9dcf1d6cc93f49fa9d4a94954", size = 138063, upload-time = "2023-11-13T06:41:38.155Z" },
-    { url = "https://files.pythonhosted.org/packages/20/81/a908c7acf36fdd01cd7277e34d7e26c72252cd99eacb84123824a52d1267/tree_sitter-0.20.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6de537bca0641775d8d175d37303d54998980fc0d997dd9aa89e16b415bf0cc3", size = 128574, upload-time = "2023-11-13T06:41:39.587Z" },
-    { url = "https://files.pythonhosted.org/packages/04/a5/a49254e0314df03d1c368ac80bff8f1307a41844ee0d55161ab68862ea93/tree_sitter-0.20.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b1c0f8c0e3e50267566f5116cdceedf4e23e8c08b55ef3becbe954a11b16e84", size = 481940, upload-time = "2023-11-13T06:41:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2e/82c394b3fb46ca0879a66837c917b0856c612c71ea0d8301a2cd659498bb/tree_sitter-0.20.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20ef2ee6d9bb8e21713949e5ff769ed670fe1217f95b7eeb6c675788438c1e6e", size = 493851, upload-time = "2023-11-13T06:41:43.388Z" },
-    { url = "https://files.pythonhosted.org/packages/10/28/a6ccb6484ee7af1587f82e91a94dc2d9502108b43a7a51b8ab19d9d603fb/tree_sitter-0.20.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b6fd1c881ab0de5faa67168db2d001eee32be5482cb4e0b21b217689a05b6fe4", size = 476635, upload-time = "2023-11-13T06:41:44.858Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/4d/9ca258188c19e5588e30c2862879c6a061d17a33cd1c24321d3d9b029591/tree_sitter-0.20.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bf47047420021d50aec529cb66387c90562350b499ddf56ecef1fc8255439e30", size = 487905, upload-time = "2023-11-13T06:41:46.579Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/e9/4797c420e71946040f44a88e095f2dbd2c20cf517eca59a3c79a0e10adf6/tree_sitter-0.20.4-cp312-cp312-win32.whl", hash = "sha256:c16b48378041fc9702b6aa3480f2ffa49ca8ea58141a862acd569e5a0679655f", size = 95293, upload-time = "2023-11-13T06:41:48.03Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/47/3e8491b14d0b6aa671a34a60c9347702f276fc4967e4c92273d5bcfd5c2e/tree_sitter-0.20.4-cp312-cp312-win_amd64.whl", hash = "sha256:973e871167079a1b1d7304d361449253efbe2a6974728ad563cf407bd02ddccb", size = 107456, upload-time = "2023-11-13T06:41:49.635Z" },
+    { url = "https://files.pythonhosted.org/packages/45/79/6dea0c098879d99f41ba919da1ea46e614fb4bf9c4d591450061aeec6fcb/tree_sitter-0.25.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9362a202144075b54f7c9f07e0b0e44a61eed7ee19e140c506b9e64c1d21ed58", size = 146928, upload-time = "2025-08-05T17:14:10.522Z" },
+    { url = "https://files.pythonhosted.org/packages/15/30/8002f4e76c7834a6101895ff7524ea29ab4f1f1da1270260ef52e2319372/tree_sitter-0.25.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:593f22529f34dd04de02f56ea6d7c2c8ec99dfab25b58be893247c1090dedd60", size = 140802, upload-time = "2025-08-05T17:14:11.38Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/d297ad9d4a4b26f551a5ca49afe48fdbcb20f058c2eff8d8463ad6c0eed1/tree_sitter-0.25.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ebb6849f76e1cbfa223303fa680da533d452e378d5fe372598e4752838ca7929", size = 606762, upload-time = "2025-08-05T17:14:12.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/1c/05a623cfb420b10d5f782d4ec064cf00fbfa9c21b8526ca4fd042f80acff/tree_sitter-0.25.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:034d4544bb0f82e449033d76dd083b131c3f9ecb5e37d3475f80ae55e8f382bd", size = 634632, upload-time = "2025-08-05T17:14:13.21Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/f05fd5a2331c16d428efb8eef32dfb80dc6565438146e34e9a235ecd7925/tree_sitter-0.25.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:46a9b721560070f2f980105266e28a17d3149485582cdba14d66dca14692e932", size = 630756, upload-time = "2025-08-05T17:14:14.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/79f3c5d53d1721b95ab6cda0368192a4f1d367e3a5ff7ac21d77e9841782/tree_sitter-0.25.1-cp312-cp312-win_amd64.whl", hash = "sha256:9a5c522b1350a626dc1cbc5dc203133caeaa114d3f65e400445e8b02f18b343b", size = 127157, upload-time = "2025-08-05T17:14:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b7/07c4e3f71af0096db6c2ecd83e7d61584e3891c79cb39b208082312d1d60/tree_sitter-0.25.1-cp312-cp312-win_arm64.whl", hash = "sha256:43e7b8e83f9fc29ca62e7d2aa8c38e3fa806ff3fc65e0d501d18588dc1509888", size = 113910, upload-time = "2025-08-05T17:14:16.385Z" },
 ]
 
 [[package]]
-name = "tree-sitter-languages"
-version = "1.10.2"
+name = "tree-sitter-c-sharp"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/04/f6c2df4c53a588ccd88d50851155945cff8cd887bd70c175e00aaade7edf/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd", size = 372235, upload-time = "2024-11-11T05:25:19.424Z" },
+    { url = "https://files.pythonhosted.org/packages/99/10/1aa9486f1e28fc22810fa92cbdc54e1051e7f5536a5e5b5e9695f609b31e/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e", size = 419046, upload-time = "2024-11-11T05:25:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/72/fc6846795bcdae2f8aa94cc8b1d1af33d634e08be63e294ff0d6794b1efc/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8024e466b2f5611c6dc90321f232d8584893c7fb88b75e4a831992f877616d2", size = 402830, upload-time = "2024-11-11T05:25:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3a/b6028c5890ce6653807d5fa88c72232c027c6ceb480dbeb3b186d60e5971/tree_sitter_c_sharp-0.23.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7f9bf876866835492281d336b9e1f9626ab668737f74e914c31d285261507da7", size = 397880, upload-time = "2024-11-11T05:25:25.937Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d2/4facaa34b40f8104d8751746d0e1cd2ddf0beb9f1404b736b97f372bd1f3/tree_sitter_c_sharp-0.23.1-cp39-abi3-win_amd64.whl", hash = "sha256:ae9a9e859e8f44e2b07578d44f9a220d3fa25b688966708af6aa55d42abeebb3", size = 377562, upload-time = "2024-11-11T05:25:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/88/3cf6bd9959d94d1fec1e6a9c530c5f08ff4115a474f62aedb5fedb0f7241/tree_sitter_c_sharp-0.23.1-cp39-abi3-win_arm64.whl", hash = "sha256:c81548347a93347be4f48cb63ec7d60ef4b0efa91313330e69641e49aa5a08c5", size = 375157, upload-time = "2024-11-11T05:25:30.839Z" },
+]
+
+[[package]]
+name = "tree-sitter-embedded-template"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/d6/5a58ea2f0480f5ed188b733114a8c275532a2fd1568b3898793b13d28af5/tree_sitter_embedded_template-0.23.2.tar.gz", hash = "sha256:7b24dcf2e92497f54323e617564d36866230a8bfb719dbb7b45b461510dcddaa", size = 8471, upload-time = "2024-11-11T06:54:05.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c1/be0c48ed9609b720e74ade86f24ea086e353fe9c7405ee9630c3d52d09a2/tree_sitter_embedded_template-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:a505c2d2494464029d79db541cab52f6da5fb326bf3d355e69bf98b84eb89ae0", size = 9554, upload-time = "2024-11-11T06:53:58Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a5/7c12f5d302525ee36d1eafc28a68e4454da5bad208436d547326bee4ed76/tree_sitter_embedded_template-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:28028b93b42cc3753261ae7ce066675d407f59de512417524f9c3ab7792b1d37", size = 10051, upload-time = "2024-11-11T06:53:59.346Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/95aaba8b64b849200bd7d4ae510cc394ecaef46a031499cbff301766970d/tree_sitter_embedded_template-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec399d59ce93ffb60759a2d96053eed529f3c3f6a27128f261710d0d0de60e10", size = 17532, upload-time = "2024-11-11T06:54:00.053Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f8/8c837b898f00b35f9f3f76a4abc525e80866a69343083c9ff329e17ecb03/tree_sitter_embedded_template-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcfa01f62b88d50dbcb736cc23baec8ddbfe08daacfdc613eee8c04ab65efd09", size = 17394, upload-time = "2024-11-11T06:54:00.841Z" },
+    { url = "https://files.pythonhosted.org/packages/89/9b/893adf9e465d2d7f14870871bf2f3b30045e5ac417cb596f667a72eda493/tree_sitter_embedded_template-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6debd24791466f887109a433c31aa4a5deeba2b217817521c745a4e748a944ed", size = 16439, upload-time = "2024-11-11T06:54:02.214Z" },
+    { url = "https://files.pythonhosted.org/packages/40/96/e79934572723673db9f867000500c6eea61a37705e02c7aee9ee031bbb6f/tree_sitter_embedded_template-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:158fecb38be5b15db0190ef7238e5248f24bf32ae3cab93bc1197e293a5641eb", size = 12572, upload-time = "2024-11-11T06:54:03.481Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/27f678b9874e4e2e39ddc6f5cce3374c8c60e6046ea8588a491ab6fc9fcb/tree_sitter_embedded_template-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:9f1f3b79fe273f3d15a5b64c85fc6ebfb48decfbe8542accd05f5b7694860df0", size = 11232, upload-time = "2024-11-11T06:54:04.799Z" },
+]
+
+[[package]]
+name = "tree-sitter-language-pack"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tree-sitter" },
+    { name = "tree-sitter-c-sharp" },
+    { name = "tree-sitter-embedded-template" },
+    { name = "tree-sitter-yaml" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/8725bf725969681b9ab862eef80b2c4f97d6983286a57dddbe6b8bc41d9b/tree_sitter_language_pack-0.9.0.tar.gz", hash = "sha256:900eb3bd82c1bcf5cf20ed852b1b6fdc7eae89e40a860fa5e221a796687c359a", size = 46642261, upload-time = "2025-07-08T06:53:59.624Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/bf/a9bd2d6ecbd053de0a5a50c150105b69c90eb49089f9e1d4fc4937e86adc/tree_sitter_languages-1.10.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c0f4c8b2734c45859edc7fcaaeaab97a074114111b5ba51ab4ec7ed52104763c", size = 8884771, upload-time = "2024-02-04T10:28:39.655Z" },
-    { url = "https://files.pythonhosted.org/packages/14/fb/1f6fe5903aeb7435cc66d4b56621e9a30a4de64420555b999de65b31fcae/tree_sitter_languages-1.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:eecd3c1244ac3425b7a82ba9125b4ddb45d953bbe61de114c0334fd89b7fe782", size = 9724562, upload-time = "2024-02-04T10:28:42.275Z" },
-    { url = "https://files.pythonhosted.org/packages/20/6c/1855a65c9d6b50600f7a68e0182153db7cb12ff81fdebd93e87851dfdd8f/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15db3c8510bc39a80147ee7421bf4782c15c09581c1dc2237ea89cefbd95b846", size = 8678682, upload-time = "2024-02-04T10:28:44.642Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/75/eff180f187ce4dc3e5177b3f8508e0061ea786ac44f409cf69cf24bf31a6/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92c6487a6feea683154d3e06e6db68c30e0ae749a7ce4ce90b9e4e46b78c85c7", size = 8595099, upload-time = "2024-02-04T10:28:47.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/e6/eddc76ad899d77adcb5fca6cdf651eb1d33b4a799456bf303540f6cf8204/tree_sitter_languages-1.10.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2f1cd1d1bdd65332f9c2b67d49dcf148cf1ded752851d159ac3e5ee4f4d260", size = 8433569, upload-time = "2024-02-04T10:28:50.404Z" },
-    { url = "https://files.pythonhosted.org/packages/06/95/a13da048c33a876d0475974484bf66b1fae07226e8654b1365ab549309cd/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:976c8039165b8e12f17a01ddee9f4e23ec6e352b165ad29b44d2bf04e2fbe77e", size = 9196003, upload-time = "2024-02-04T10:28:52.466Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/13/9e5cb03914d60dd51047ecbfab5400309fbab14bb25014af388f492da044/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:dafbbdf16bf668a580902e1620f4baa1913e79438abcce721a50647564c687b9", size = 9175560, upload-time = "2024-02-04T10:28:55.064Z" },
-    { url = "https://files.pythonhosted.org/packages/19/76/25bb32a9be1c476e388835d5c8de5af2920af055e295770003683896cfe2/tree_sitter_languages-1.10.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1aeabd3d60d6d276b73cd8f3739d595b1299d123cc079a317f1a5b3c5461e2ca", size = 8956249, upload-time = "2024-02-04T10:28:57.094Z" },
-    { url = "https://files.pythonhosted.org/packages/52/01/8e2f97a444d25dde1380ec20b338722f733b6cc290524357b1be3dd452ab/tree_sitter_languages-1.10.2-cp312-cp312-win32.whl", hash = "sha256:fab8ee641914098e8933b87ea3d657bea4dd00723c1ee7038b847b12eeeef4f5", size = 8363094, upload-time = "2024-02-04T10:28:59.156Z" },
-    { url = "https://files.pythonhosted.org/packages/47/58/0262e875dd899447476a8ffde7829df3716ffa772990095c65d6de1f053c/tree_sitter_languages-1.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:5e606430d736367e5787fa5a7a0c5a1ec9b85eded0b3596bbc0d83532a40810b", size = 8268983, upload-time = "2024-02-04T10:29:00.987Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/62/df6edf2c14e2ffd00fc14cdea2d917e724bea10a85a163cf77e4fe28162c/tree_sitter_language_pack-0.9.0-cp39-abi3-macosx_10_13_universal2.whl", hash = "sha256:da4a643618148d6ca62343c8457bfc472e7d122503d97fac237f06acbbd8aa33", size = 30139786, upload-time = "2025-07-08T06:53:47.181Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/5ff123e9e1e73e00c4f262e5d16f4928d43ea82bf80b9ca82ecf250ceeaa/tree_sitter_language_pack-0.9.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f1db4abded09ba0cb7a2358b4f3a2937fe9bfd4fdd4b4ad9e89a0c283e1329f", size = 18650360, upload-time = "2025-07-08T06:53:50.442Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a0/485128abc18bbb7d78a2dd0c6487315a71b609877778a9796968f43f36d9/tree_sitter_language_pack-0.9.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:5922afd7c2a2e632c4c69af10982b6017fd00ced70630c5f9e5d7c0d7d311b27", size = 18504901, upload-time = "2025-07-08T06:53:52.967Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c3/a24133447602bd220fea895395896c50b5ef7feebfcafa6dabf5a460fd80/tree_sitter_language_pack-0.9.0-cp39-abi3-win_amd64.whl", hash = "sha256:b3542ddaa1505716bc5b761e1aa718eafe64df988d700da62637cee501ac260f", size = 15279483, upload-time = "2025-07-08T06:53:56.108Z" },
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d0/97899f366e3d982ad92dd83faa2b1dd0060e5db99990e0d7f660902493f8/tree_sitter_yaml-0.7.1.tar.gz", hash = "sha256:2cea5f8d4ca4d10439bd7d9e458c61b330cb33cf7a92e4ef1d428e10e1ab7e2c", size = 91533, upload-time = "2025-05-22T13:34:57.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/7e/83a40de4315b8f9975d3fd562071bda8fa1dfc088b3359d048003f174fd0/tree_sitter_yaml-0.7.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0256632914d6eb21819f21a85bab649505496ac01fac940eb08a410669346822", size = 43788, upload-time = "2025-05-22T13:34:49.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/760b38e31f9ca1e8667cf82a07119956dcb865728f7d777a22f5ddf296c6/tree_sitter_yaml-0.7.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf9dd2649392e1f28a20f920f49acd9398cfb872876e338aa84562f8f868dc4d", size = 45001, upload-time = "2025-05-22T13:34:50.397Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e9/6d8d502eeb96fb363c1ac926ac456afc55019836fc675263fd23754dfdc6/tree_sitter_yaml-0.7.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94eb8fcb1ac8e43f7da47e63880b6f283524460153f08420a167c1721e42b08a", size = 93852, upload-time = "2025-05-22T13:34:51.728Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ef/b84bc6aaaa08022b4cc1d36212e837ce051306d50dd62993ffc21c9bf4ab/tree_sitter_yaml-0.7.1-cp310-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30410089828ebdece9abf3aa16b2e172b84cf2fd90a2b7d8022f6ed8cde90ecb", size = 92125, upload-time = "2025-05-22T13:34:52.731Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0c/5caa26da012c93da1eadf66c6babb1b1e2e8dd4434668c7232739df87e46/tree_sitter_yaml-0.7.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:219af34f4b35b5c16f25426cc3f90cf725fbba17c9592f78504086e67787be09", size = 90443, upload-time = "2025-05-22T13:34:53.626Z" },
+    { url = "https://files.pythonhosted.org/packages/92/25/a14297ea2a575bc3c19fcf58a5983a926ad732c32af23a346d7fa0563d8d/tree_sitter_yaml-0.7.1-cp310-abi3-win_amd64.whl", hash = "sha256:550645223d68b7d6b4cfedf4972754724e64d369ec321fa33f57d3ca54cafc7c", size = 45517, upload-time = "2025-05-22T13:34:54.545Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fa/b25e688df5b4e024bc3627bc3f951524ef9c8b0756f0646411efa5063a10/tree_sitter_yaml-0.7.1-cp310-abi3-win_arm64.whl", hash = "sha256:298ade69ad61f76bb3e50ced809650ec30521a51aa2708166b176419ccb0a6ba", size = 43801, upload-time = "2025-05-22T13:34:55.471Z" },
 ]
 
 [[package]]
@@ -1050,6 +1234,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary
- Replace the unmaintained [`tree-sitter-languages`](https://github.com/grantjenks/py-tree-sitter-languages) with [`tree-sitter-language-pack`](https://github.com/tree-sitter/tree-sitter-language-pack)
- Add `isort` and `black` as pre-commit hooks to enforce consistent code style

### Motivation
- `tree-sitter-languages` is no longer maintained ([status note](https://github.com/grantjenks/py-tree-sitter-languages?tab=readme-ov-file#status))
- Switching to `tree-sitter-language-pack` ensures ongoing support for Tree-sitter grammars
- Using pre-commit hooks for `isort` and `black` automatically standardizes imports and formatting, reducing review overhead and human errors

### Changes
- Updated dependency from `tree-sitter-languages` → `tree-sitter-language-pack`
- Adjusted imports and usage accordingly
- Added `.pre-commit-config.yaml` with `isort` and `black`, and reformatted codebase

### Impact
- No breaking changes for end users
- Code style is now automatically enforced via pre-commit
